### PR TITLE
fix npm-runscript

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node ./bin/www",
-    "postinstall": "node ./tools/postinstall",
+    "postinstall": "node ./scripts/postinstall",
     "production": "gulp production",
     "build": "gulp build",
     "server:develop": "gulp server:develop",


### PR DESCRIPTION
scriptsのpostinstallのパスが以前のtoolsになっていたため、scriptsに修正