### PR TITLE
BabelのRequire hookの変更への対応

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 /*
   gulpfile.js
 */
-require('babel-core/register');
+require('babel-register');
 
 var requireDir = require('require-dir');
 

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
   },
   "dependencies": {
     "autoprefixer": "^6.3.1",
-    "babel-core": "^6.4.5",
     "babel-polyfill": "^6.3.14",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-2": "^6.3.13",
+    "babel-register": "^6.5.1",
     "babelify": "^7.2.0",
     "body-parser": "^1.14.2",
     "browser-sync": "^2.11.1",


### PR DESCRIPTION
babe-registerが提供されるようになったため、babel-coreの代わりにbabel-registerをインストールし、直接利用するように修正